### PR TITLE
Expand .gitignore for Rust + Node.js coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,39 @@
-core/target/
+# Rust build artifacts
+**/target/
+**/*.rs.bk
+
+# SQLite databases (generated at runtime)
 *.db
 *.db-journal
+*.db-wal
+*.db-shm
+
+# Node / npm
+node_modules/
+*.tgz
+.npm/
+
+# Logs
+*.log
+npm-debug.log*
+
+# Environment & secrets
+.env
+.env.*
+
+# OS files
 .DS_Store
+Thumbs.db
+
+# Editor / IDE
 *.swp
+*.swo
+*~
 .vscode/
 .idea/
+*.sublime-project
+*.sublime-workspace
+
+# Temporary files
+*.tmp
+*.bak


### PR DESCRIPTION
## Summary
- Generalize `core/target/` to `**/target/` so any nested Cargo build directory is ignored
- Add missing entries for `node_modules/`, npm artifacts (`.tgz`, `.npm/`), and log files
- Add `.env` / `.env.*` to prevent accidental commits of secrets
- Add SQLite WAL/SHM journal files (`*.db-wal`, `*.db-shm`)
- Add additional editor/IDE patterns (`*.swo`, `*~`, Sublime) and OS files (`Thumbs.db`)

## Test plan
- [ ] Verify `git status` no longer shows `node_modules/` or `.env` files if present
- [ ] Confirm existing tracked files are unaffected by the broader `**/target/` glob

🤖 Generated with [Claude Code](https://claude.com/claude-code)