### PR TITLE
Fix UTF-8 panics in string truncation

### DIFF
--- a/core/src/compress/conversation.rs
+++ b/core/src/compress/conversation.rs
@@ -196,7 +196,13 @@ fn trim_turn(turn: &Turn, level: CompressionLevel) -> String {
 fn summarize_turn(turn: &Turn) -> String {
     let first_line = turn.raw.lines().next().unwrap_or("");
     let truncated = if first_line.len() > 100 {
-        format!("{}...", &first_line[..100])
+        // Find a char boundary at or before 100 to avoid panicking on multi-byte UTF-8.
+        // Slicing directly at byte 100 will panic if it falls inside a multi-byte character.
+        let mut end = 100;
+        while end > 0 && !first_line.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &first_line[..end])
     } else {
         first_line.to_string()
     };

--- a/core/src/compress/mcp.rs
+++ b/core/src/compress/mcp.rs
@@ -194,6 +194,12 @@ fn truncate(s: &str, max: usize) -> String {
     if s.len() <= max {
         s.to_string()
     } else {
-        format!("{}...", &s[..max])
+        // Find a char boundary at or before `max` to avoid panicking on multi-byte UTF-8.
+        // Slicing directly at `max` will panic if it falls inside a multi-byte character.
+        let mut end = max;
+        while end > 0 && !s.is_char_boundary(end) {
+            end -= 1;
+        }
+        format!("{}...", &s[..end])
     }
 }


### PR DESCRIPTION
## Summary
- **Bug**: `truncate()` in `mcp.rs` and `summarize_turn()` in `conversation.rs` slice strings at a raw byte offset (`&s[..max]`). This panics at runtime if the offset lands inside a multi-byte UTF-8 character (emoji, CJK, accented characters, etc.).
- **Fix**: Walk back from the target offset to the nearest char boundary using `is_char_boundary()` before slicing. This is safe on all stable Rust versions.
- **Files changed**: `core/src/compress/mcp.rs`, `core/src/compress/conversation.rs`

## Test plan
- [ ] Run `cargo test` to verify no regressions
- [ ] Compress MCP tool descriptions containing emoji or non-ASCII characters (e.g. `tokenforge compress --type mcp` with a schema whose description contains "日本語" or "🚀")
- [ ] Compress conversations with non-ASCII turn prefixes exceeding 100 bytes

🤖 Generated with [Claude Code](https://claude.com/claude-code)