### PR TITLE
feat: add diff command for compression inspection

### DIFF
--- a/core/Cargo.lock
+++ b/core/Cargo.lock
@@ -806,7 +806,7 @@ dependencies = [
 
 [[package]]
 name = "tokenforge"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "anyhow",
  "blake3",

--- a/core/src/context/store.rs
+++ b/core/src/context/store.rs
@@ -271,6 +271,32 @@ impl Store {
         Ok(result)
     }
 
+    /// Get original content, compressed content, and metadata for a hash.
+    /// Returns (original, compressed, content_type, original_tokens, compressed_tokens).
+    pub fn get_compression_pair(
+        &self,
+        content_hash: &str,
+    ) -> Result<(String, String, String, usize, usize)> {
+        let (blob, compressed, content_type, orig_tok, comp_tok): (
+            Vec<u8>,
+            String,
+            String,
+            i64,
+            i64,
+        ) = self.conn.query_row(
+            "SELECT original_content, compressed_content, content_type, original_tokens, compressed_tokens
+             FROM content_store WHERE original_hash = ?1 ORDER BY id DESC LIMIT 1",
+            params![content_hash],
+            |row| Ok((row.get(0)?, row.get(1)?, row.get(2)?, row.get(3)?, row.get(4)?)),
+        ).context("content not found for hash")?;
+
+        let decompressed = zstd::decode_all(blob.as_slice())
+            .context("zstd decompression failed")?;
+        let original = String::from_utf8(decompressed).context("content is not valid UTF-8")?;
+
+        Ok((original, compressed, content_type, orig_tok as usize, comp_tok as usize))
+    }
+
     /// Get top accessed files for a project.
     pub fn top_files(&self, project_path: &str, limit: usize) -> Result<Vec<(String, i64)>> {
         let mut stmt = self.conn.prepare(

--- a/core/src/lib.rs
+++ b/core/src/lib.rs
@@ -180,6 +180,19 @@ pub struct TypeStats {
     pub count: usize,
 }
 
+/// Result of diffing original vs compressed content.
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct DiffResult {
+    pub hash: String,
+    pub unified_diff: String,
+    pub original_bytes: usize,
+    pub compressed_bytes: usize,
+    pub original_tokens: usize,
+    pub compressed_tokens: usize,
+    pub savings_pct: f64,
+    pub content_type: String,
+}
+
 /// Top-level engine.
 pub struct Engine {
     db_path: PathBuf,
@@ -294,6 +307,33 @@ impl Engine {
     pub fn expand(&self, content_hash: &str) -> anyhow::Result<String> {
         let store = context::store::Store::open(&self.db_path)?;
         store.get_original(content_hash)
+    }
+
+    /// Show diff between original and compressed content for a hash.
+    pub fn diff(&self, content_hash: &str) -> anyhow::Result<DiffResult> {
+        let store = context::store::Store::open(&self.db_path)?;
+        let (original, compressed, content_type, original_tokens, compressed_tokens) =
+            store.get_compression_pair(content_hash)?;
+
+        let patch = diffy::create_patch(&original, &compressed);
+        let unified_diff = patch.to_string();
+
+        let ratio = if original_tokens > 0 {
+            1.0 - (compressed_tokens as f64 / original_tokens as f64)
+        } else {
+            0.0
+        };
+
+        Ok(DiffResult {
+            hash: content_hash.to_string(),
+            unified_diff,
+            original_bytes: original.len(),
+            compressed_bytes: compressed.len(),
+            original_tokens,
+            compressed_tokens,
+            savings_pct: ratio * 100.0,
+            content_type,
+        })
     }
 }
 

--- a/core/src/main.rs
+++ b/core/src/main.rs
@@ -115,6 +115,12 @@ enum Commands {
         hash: String,
     },
 
+    /// Show diff between original and compressed content
+    Diff {
+        /// Content hash
+        hash: String,
+    },
+
     /// Run as MCP server over stdio (JSON-RPC 2.0)
     Serve,
 
@@ -335,6 +341,30 @@ fn main() -> Result<()> {
             let engine = Engine::new(db_path);
             let original = engine.expand(&hash)?;
             print!("{original}");
+        }
+
+        Commands::Diff { hash } => {
+            let engine = Engine::new(db_path);
+            let result = engine.diff(&hash)?;
+
+            if cli.json {
+                println!("{}", serde_json::to_string_pretty(&result)?);
+            } else {
+                println!("Diff for hash: {}", result.hash);
+                println!("{}", "─".repeat(50));
+                println!("  Type:       {}", result.content_type);
+                println!(
+                    "  Original:   {} bytes, {} tokens",
+                    result.original_bytes, result.original_tokens
+                );
+                println!(
+                    "  Compressed: {} bytes, {} tokens",
+                    result.compressed_bytes, result.compressed_tokens
+                );
+                println!("  Savings:    {:.1}%", result.savings_pct);
+                println!("{}", "─".repeat(50));
+                print!("{}", result.unified_diff);
+            }
         }
 
         Commands::Serve => {

--- a/core/src/mcp_server.rs
+++ b/core/src/mcp_server.rs
@@ -172,6 +172,20 @@ impl McpServer {
                                 }
                             }
                         }
+                    },
+                    {
+                        "name": "tokenforge_diff",
+                        "description": "Show a unified diff between original and compressed content for a given hash. Highlights what was removed/changed during compression, with size and token stats.",
+                        "inputSchema": {
+                            "type": "object",
+                            "properties": {
+                                "hash": {
+                                    "type": "string",
+                                    "description": "Blake3 hash returned from tokenforge_compress"
+                                }
+                            },
+                            "required": ["hash"]
+                        }
                     }
                 ]
             }
@@ -193,6 +207,7 @@ impl McpServer {
             "tokenforge_expand"   => self.tool_expand(&args),
             "tokenforge_stats"    => self.tool_stats(&args),
             "tokenforge_bench"    => self.tool_bench(&args),
+            "tokenforge_diff"     => self.tool_diff(&args),
             _ => (format!("Unknown tool: {name}"), true),
         };
 
@@ -294,6 +309,24 @@ impl McpServer {
                 }
             }
             Err(e) => (format!("Bench error: {e}"), true),
+        }
+    }
+
+    fn tool_diff(&self, args: &Value) -> (String, bool) {
+        let hash = match args.get("hash").and_then(Value::as_str) {
+            Some(h) => h,
+            None => return ("Missing required field: hash".to_string(), true),
+        };
+
+        let engine = Engine::new(self.db_path.clone());
+        match engine.diff(hash) {
+            Ok(result) => {
+                match serde_json::to_string_pretty(&result) {
+                    Ok(s) => (s, false),
+                    Err(e) => (format!("Serialization error: {e}"), true),
+                }
+            }
+            Err(e) => (format!("Diff error: {e}"), true),
         }
     }
 }


### PR DESCRIPTION
## Summary
- Adds `tokenforge diff <hash>` CLI subcommand that retrieves original and compressed content from SQLite, generates a unified diff, and displays stats (original/compressed size in bytes and tokens, savings percentage, content type)
- Adds `tokenforge_diff` MCP tool with the same functionality for programmatic use via JSON-RPC
- Adds `Store::get_compression_pair()` to retrieve both original and compressed content along with metadata for a given hash

## Test plan
- [x] All 20 existing tests pass (1 pre-existing failure in `summarizes_test_output` is unrelated)
- [x] `cargo build` succeeds
- [x] `tokenforge --help` shows the new `diff` subcommand
- [ ] Manual: run `tokenforge compress <file>`, then `tokenforge diff <hash>` to verify unified diff output
- [ ] Manual: run with `--json` flag to verify JSON output format

🤖 Generated with [Claude Code](https://claude.com/claude-code)